### PR TITLE
types and helpers for `T15` and `T16`

### DIFF
--- a/src/Toop.elm
+++ b/src/Toop.elm
@@ -1,8 +1,8 @@
-module Toop exposing (T1(..), T2(..), T3(..), T4(..), T5(..), T6(..), T7(..), T8(..), T9(..), T10(..), T11(..), T12(..), T13(..), T14(..))
+module Toop exposing (T1(..), T2(..), T3(..), T4(..), T5(..), T6(..), T7(..), T8(..), T9(..), T10(..), T11(..), T12(..), T13(..), T14(..), T15(..), T16(..))
 
 {-| A set of tuple-like data structures, allowing more than 3 elements.
 
-@docs T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+@docs T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16
 
 -}
 
@@ -89,3 +89,15 @@ type T13 a b c d e f g h i j k l m
 -}
 type T14 a b c d e f g h i j k l m n
     = T14 a b c d e f g h i j k l m n
+
+
+{-| 15 element toop.
+-}
+type T15 a b c d e f g h i j k l m n o
+    = T15 a b c d e f g h i j k l m n o
+
+
+{-| 16 element toop.
+-}
+type T16 a b c d e f g h i j k l m n o p
+    = T16 a b c d e f g h i j k l m n o p

--- a/src/Toop/Apply.elm
+++ b/src/Toop/Apply.elm
@@ -1,8 +1,8 @@
-module Toop.Apply exposing (applyT1, applyT2, applyT3, applyT4, applyT5, applyT6, applyT7, applyT8, applyT9, applyT10, applyT11, applyT12, applyT13, applyT14)
+module Toop.Apply exposing (applyT1, applyT2, applyT3, applyT4, applyT5, applyT6, applyT7, applyT8, applyT9, applyT10, applyT11, applyT12, applyT13, applyT14, applyT15, applyT16)
 
 {-| given a function of N arguments, apply that function to a toop of size N.
 
-@docs applyT1, applyT2, applyT3, applyT4, applyT5, applyT6, applyT7, applyT8, applyT9, applyT10, applyT11, applyT12, applyT13, applyT14
+@docs applyT1, applyT2, applyT3, applyT4, applyT5, applyT6, applyT7, applyT8, applyT9, applyT10, applyT11, applyT12, applyT13, applyT14, applyT15, applyT16
 
 -}
 
@@ -105,3 +105,17 @@ applyT13 y (T13 a b c d e f g h i j k l m) =
 applyT14 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> n -> x) -> T14 a b c d e f g h i j k l m n -> x
 applyT14 y (T14 a b c d e f g h i j k l m n) =
     y a b c d e f g h i j k l m n
+
+
+{-| 15 element apply.
+-}
+applyT15 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> n -> o -> x) -> T15 a b c d e f g h i j k l m n o -> x
+applyT15 y (T15 a b c d e f g h i j k l m n o) =
+    y a b c d e f g h i j k l m n o
+
+
+{-| 16 element apply.
+-}
+applyT16 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> n -> o -> p -> x) -> T16 a b c d e f g h i j k l m n o p -> x
+applyT16 y (T16 a b c d e f g h i j k l m n o p) =
+    y a b c d e f g h i j k l m n o p

--- a/src/Toop/Result.elm
+++ b/src/Toop/Result.elm
@@ -1,9 +1,9 @@
-module Toop.Result exposing (andMap, resT1, resT2, resT3, resT4, resT5, resT6, resT7, resT8, resT9, resT10, resT11, resT12, resT13, resT14)
+module Toop.Result exposing (andMap, resT1, resT2, resT3, resT4, resT5, resT6, resT7, resT8, resT9, resT10, resT11, resT12, resT13, resT14, resT15, resT16)
 
 {-| given a Toop of N results, which all share a common Err type, either return a Toop of
 all the 'Ok' values, or the first Err.
 
-@docs andMap, resT1, resT2, resT3, resT4, resT5, resT6, resT7, resT8, resT9, resT10, resT11, resT12, resT13, resT14
+@docs andMap, resT1, resT2, resT3, resT4, resT5, resT6, resT7, resT8, resT9, resT10, resT11, resT12, resT13, resT14, resT15, resT16
 
 -}
 
@@ -246,3 +246,52 @@ resT14 (T14 rsa rsb rsc rsd rse rsf rsg rsh rsi rsj rsk rsl rsm rsn) =
         |> andMap rsl
         |> andMap rsm
         |> andMap rsn
+
+
+{-| 15 element toop.
+-}
+resT15 :
+    T15 (Result err a) (Result err b) (Result err c) (Result err d) (Result err e) (Result err f) (Result err g) (Result err h) (Result err i) (Result err j) (Result err k) (Result err l) (Result err m) (Result err n) (Result err o)
+    -> Result err (T15 a b c d e f g h i j k l m n o)
+resT15 (T15 rsa rsb rsc rsd rse rsf rsg rsh rsi rsj rsk rsl rsm rsn rso) =
+    Ok T15
+        |> andMap rsa
+        |> andMap rsb
+        |> andMap rsc
+        |> andMap rsd
+        |> andMap rse
+        |> andMap rsf
+        |> andMap rsg
+        |> andMap rsh
+        |> andMap rsi
+        |> andMap rsj
+        |> andMap rsk
+        |> andMap rsl
+        |> andMap rsm
+        |> andMap rsn
+        |> andMap rso
+
+
+{-| 16 element toop.
+-}
+resT16 :
+    T16 (Result err a) (Result err b) (Result err c) (Result err d) (Result err e) (Result err f) (Result err g) (Result err h) (Result err i) (Result err j) (Result err k) (Result err l) (Result err m) (Result err n) (Result err o) (Result err p)
+    -> Result err (T16 a b c d e f g h i j k l m n o p)
+resT16 (T16 rsa rsb rsc rsd rse rsf rsg rsh rsi rsj rsk rsl rsm rsn rso rsp) =
+    Ok T16
+        |> andMap rsa
+        |> andMap rsb
+        |> andMap rsc
+        |> andMap rsd
+        |> andMap rse
+        |> andMap rsf
+        |> andMap rsg
+        |> andMap rsh
+        |> andMap rsi
+        |> andMap rsj
+        |> andMap rsk
+        |> andMap rsl
+        |> andMap rsm
+        |> andMap rsn
+        |> andMap rso
+        |> andMap rsp

--- a/src/Toop/Take.elm
+++ b/src/Toop/Take.elm
@@ -1,8 +1,8 @@
-module Toop.Take exposing (takeT1, takeT2, takeT3, takeT4, takeT5, takeT6, takeT7, takeT8, takeT9, takeT10, takeT11, takeT12, takeT13, takeT14)
+module Toop.Take exposing (takeT1, takeT2, takeT3, takeT4, takeT5, takeT6, takeT7, takeT8, takeT9, takeT10, takeT11, takeT12, takeT13, takeT14, takeT15, takeT16)
 
 {-| functions to make an N element toop from a List.
 
-@docs takeT1, takeT2, takeT3, takeT4, takeT5, takeT6, takeT7, takeT8, takeT9, takeT10, takeT11, takeT12, takeT13, takeT14
+@docs takeT1, takeT2, takeT3, takeT4, takeT5, takeT6, takeT7, takeT8, takeT9, takeT10, takeT11, takeT12, takeT13, takeT14, takeT15, takeT16
 
 -}
 
@@ -183,6 +183,49 @@ takeT13 l =
 takeT14 : List a -> Maybe ( T14 a a a a a a a a a a a a a a, List a )
 takeT14 l =
     andX T14 l
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+
+
+{-| 15 element take.
+-}
+takeT15 : List a -> Maybe ( T15 a a a a a a a a a a a a a a a, List a )
+takeT15 l =
+    andX T15 l
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
+
+
+{-| 16 element take.
+-}
+takeT16 : List a -> Maybe ( T16 a a a a a a a a a a a a a a a a, List a )
+takeT16 l =
+    andX T16 l
+        |> Maybe.andThen (tuply andX)
+        |> Maybe.andThen (tuply andX)
         |> Maybe.andThen (tuply andX)
         |> Maybe.andThen (tuply andX)
         |> Maybe.andThen (tuply andX)


### PR DESCRIPTION
`Toop.T15` and `.T16` types were added, plus the `T<n>` suffixed helpers.

My specific use case is the conversion of `T16` of [bits](https://dark.elm.dmy.fr/packages/lue-bird/elm-bits/latest/):
```elm
case bits |> Arr.to16 of
    T16 I O O I O I O I I I O O O O O I ->
        "just an example"
```
